### PR TITLE
mako 1.3.11 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Mako" %}
-{% set version = "1.3.10" %}
+{% set version = "1.3.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
-  sha256: 99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28
+  sha256: 071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069
 
 build:
   number: 0


### PR DESCRIPTION
mako 1.3.11 

**Destination channel:** Defaults

### Links

- [PKG-13632]
- dev_url:        https://github.com/sqlalchemy/mako/tree/rel_1_3_11
- conda_forge:    https://github.com/conda-forge/mako-feedstock
- pypi:           https://pypi.org/project/mako/1.3.11
- pypi inspector: https://inspector.pypi.io/project/mako/1.3.11

### Explanation of changes:

- new version number


[PKG-13632]: https://anaconda.atlassian.net/browse/PKG-13632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ